### PR TITLE
Move types to dev depedency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "test-coverage": "jest --coverage"
   },
   "dependencies": {
-    "just-types": "^2.0.0-alpha.2"
   },
   "devDependencies": {
+    "just-types": "^2.0.0-alpha.2",
     "@parcel/packager-ts": "^2.9.3",
     "@parcel/transformer-typescript-types": "^2.9.3",
     "@testing-library/dom": "^9.3.1",


### PR DESCRIPTION
The types are a 'design time' capability leveraged by TS. They should not need to be distributed as a hard depedency of the project because then TypeScript gets included as a depedency. See: https://github.com/reaviz/reagraph/issues/235